### PR TITLE
Update csharp test to identify .net fwk version

### DIFF
--- a/evaluate/testuri.cs
+++ b/evaluate/testuri.cs
@@ -64,11 +64,7 @@ class testuri {
     var output = new Output();
 
     var assembly = Assembly.GetExecutingAssembly();
-    foreach (var name in assembly.GetReferencedAssemblies()) {
-      if (name.Name == "System") {
-        output.useragent = name.ToString();
-      }
-    }
+    output.useragent = assembly.GetCustomAttributes(typeof(TargetFrameworkAttribute)).Cast<TargetFrameworkAttribute>().First().FrameworkName;
 
     output.constructor = constructors;
 


### PR DESCRIPTION
The version property previously used to identify the useragent only identified the CLR, not the framework version.  I suspect the previous tests were run on .net 4.0.  Running the tests on .Net 4.5  show a reasonable number of differences, including differences in how the [] are handled and how ipv6 addresses are rendered.
