### PR TITLE
Make the textual description for port match the production rule

### DIFF
--- a/url.bs
+++ b/url.bs
@@ -1224,6 +1224,7 @@ ZeroOrMore:
 a solidus (<code>U+002F</code>),
 a reverse solidus (<code>U+005C</code>),
 a question mark (<code>U+003F</code>),
+a number sign (<code>U+<code>0023</code></code>),
 or the end of string is encountered.
 
 <li>Let <code>result</code> be the <a title=cleanse>cleansed</a> set of code points using

--- a/url.bs
+++ b/url.bs
@@ -864,7 +864,7 @@ Sequence:
 A scheme consists of an <a>ASCII alpha</a>,
 followed by zero or more <a>ASCII alpha</a> or any of the following
 code points: hyphen-minus (<code>U+002D</code>), plus sign (<code>U+002B</code>) or full stop
-(<code>U+002D</code>).
+(<code>U+002E</code>).
 Return the results as a lowercased string.
 
 <h4 id=rule-authority class=no-toc>authority(input)</h4>
@@ -1189,7 +1189,7 @@ Sequence:
 </pre>
 
 Return four decimal <a title='IPv4 piece'><code>8</code>-bit pieces</a> separated by full
-stop code points as a string.
+stop (U+002E) code points as a string.
 
 <h4 id=rule-decimal-byte class=no-toc>decimal-byte(input)</h4>
 

--- a/url.pegjs
+++ b/url.pegjs
@@ -945,6 +945,7 @@ DecimalByte
   a solidus (U+002F),
   a reverse solidus (U+005C),
   a question mark (U+003F),
+  a number sign (U+0023),
   or the end of string is encountered.
 
   <li>Let $result be the <a title=cleanse>cleansed</a> set of code points using

--- a/url.pegjs
+++ b/url.pegjs
@@ -479,7 +479,7 @@ NonFileRelativeScheme
   A scheme consists of an <a>ASCII alpha</a>,
   followed by zero or more <a>ASCII alpha</a> or any of the following
   code points: hyphen-minus (U+002D), plus sign (U+002B) or full stop
-  (U+002D).
+  (U+002E).
   Return the results as a lowercased string.
 */
 Scheme
@@ -916,7 +916,7 @@ H16
   returns: String
 
   Return four decimal <a title='IPv4 piece'>8-bit pieces</a> separated by full
-  stop code points as a string.
+  stop (U+002E) code points as a string.
 */
 LS32
   = a:DecimalByte '.' b:DecimalByte '.' d:DecimalByte '.' d:DecimalByte


### PR DESCRIPTION
The rule says
ZeroOrMore:
  T: any except [/\?#]

But the text fails to mention the number sign. I believe the rule to be the more accurate representation, so I have added the phrasing about a number sign, as used in other parts of the text. Unfortunately, I am not able to compile this spec using bikeshed, so I'm not certain it gives the desired results here.
